### PR TITLE
Move away from buildcurl and pull from artifactory

### DIFF
--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -21,12 +21,20 @@ module LanguagePack
 
     def fetch_untar(path, files_to_extract = nil)
       curl = curl_command("#{@host_url.join(path)} -s -o")
-      run!("#{curl} - | tar zxf - #{files_to_extract}", error_class: FetchError)
+      run!("#{curl} | tar zxf - #{files_to_extract}", error_class: FetchError)
+      print 'done - fetch_untar'
     end
 
     def fetch_bunzip2(path, files_to_extract = nil)
       curl = curl_command("#{@host_url.join(path)} -s -o")
-      run!("#{curl} - | tar jxf - #{files_to_extract}", error_class: FetchError)
+      run!("#{curl} | tar jxf - #{files_to_extract}", error_class: FetchError)
+      print 'done - fetch_bunzip2'
+    end
+
+    def fetch_xz(path, files_to_extract = nil)
+      curl = curl_command("#{@host_url.join(path)} -s -o")
+      run!("#{curl} | tar Jxf - #{files_to_extract}", error_class: FetchError)
+      print 'done - fetch_xz'
     end
 
     private
@@ -35,7 +43,8 @@ module LanguagePack
       buildcurl_mapping = {
         "ruby" => /^ruby-(.+)$/,
         "rubygem-bundler" => /^bundler-(.+)$/,
-        "libyaml" => /^libyaml-(.+)$/
+        "libyaml" => /^libyaml-(.+)$/,
+        "node" => /^node-(.+)$/
       }
       buildcurl_mapping.each do |k,v|
         if File.basename(binary, ".tgz") =~ v
@@ -51,7 +60,7 @@ module LanguagePack
     def build_dep_loc
       ENV['BUILD_DEP_LOC']
     end
-    
+
     def buildcurl_url
       ENV['BUILDCURL_URL'] || "buildcurl.com"
     end

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -32,16 +32,17 @@ module LanguagePack
     private
     def curl_command(command)
       binary, *rest = command.split(" ")
+      print "binary = #{binary}\n"
       buildcurl_mapping = {
         "ruby" => /^ruby-(.+)$/,
         "rubygem-bundler" => /^bundler-(.+)$/,
         "libyaml" => /^libyaml-(.+)$/
       }
       buildcurl_mapping.each do |k,v|
-        print k, v
+        print k, v, "\n"
         if File.basename(binary, ".tgz") =~ v
-          print "build location and file = #{build_dep_loc}/#{v}"
-          return "set -o pipefail; cat #{build_dep_loc}/#{v}"
+          print "build location and file = #{build_dep_loc}/#{binary}\n"
+          return "set -o pipefail; cat #{build_dep_loc}/#{binary}"
           #return "set -o pipefail; curl -L --get --fail --retry 3 #{buildcurl_url} -d recipe=#{k} -d version=#{$1} -d target=$TARGET #{rest.join(" ")}"
         end
       end

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -38,13 +38,20 @@ module LanguagePack
         "libyaml" => /^libyaml-(.+)$/
       }
       buildcurl_mapping.each do |k,v|
+        print k, v
         if File.basename(binary, ".tgz") =~ v
-          return "set -o pipefail; curl -L --get --fail --retry 3 #{buildcurl_url} -d recipe=#{k} -d version=#{$1} -d target=$TARGET #{rest.join(" ")}"
+          print "build location and file = #{build_dep_loc}/#{v}"
+          return "set -o pipefail; cat #{build_dep_loc}/#{v}"
+          #return "set -o pipefail; curl -L --get --fail --retry 3 #{buildcurl_url} -d recipe=#{k} -d version=#{$1} -d target=$TARGET #{rest.join(" ")}"
         end
       end
       "set -o pipefail; curl -L --fail --retry 3 --retry-delay 1 --connect-timeout #{curl_connect_timeout_in_seconds} --max-time #{curl_timeout_in_seconds} #{command}"
     end
 
+    def build_dep_loc
+      ENV['BUILD_DEP_LOC']
+    end
+    
     def buildcurl_url
       ENV['BUILDCURL_URL'] || "buildcurl.com"
     end

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -32,14 +32,12 @@ module LanguagePack
     private
     def curl_command(command)
       binary, *rest = command.split(" ")
-      print "binary = #{binary}\n"
       buildcurl_mapping = {
         "ruby" => /^ruby-(.+)$/,
         "rubygem-bundler" => /^bundler-(.+)$/,
         "libyaml" => /^libyaml-(.+)$/
       }
       buildcurl_mapping.each do |k,v|
-        print k, v, "\n"
         if File.basename(binary, ".tgz") =~ v
           filename = File.basename(binary)
           print "build location and file = #{build_dep_loc}/#{filename}\n"

--- a/lib/language_pack/fetcher.rb
+++ b/lib/language_pack/fetcher.rb
@@ -41,8 +41,9 @@ module LanguagePack
       buildcurl_mapping.each do |k,v|
         print k, v, "\n"
         if File.basename(binary, ".tgz") =~ v
-          print "build location and file = #{build_dep_loc}/#{binary}\n"
-          return "set -o pipefail; cat #{build_dep_loc}/#{binary}"
+          filename = File.basename(binary)
+          print "build location and file = #{build_dep_loc}/#{filename}\n"
+          return "set -o pipefail; cat #{build_dep_loc}/#{filename}"
           #return "set -o pipefail; curl -L --get --fail --retry 3 #{buildcurl_url} -d recipe=#{k} -d version=#{$1} -d target=$TARGET #{rest.join(" ")}"
         end
       end

--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -9,13 +9,11 @@ class LanguagePack::NodeInstaller
   NODEJS_BASE_URL     = "#{NODEJS_BASE}/v#{MODERN_NODE_VERSION}/"
 
   def initialize(stack)
-    print "Initialized node installer\n"
     @fetchers = {
       modern: LanguagePack::Fetcher.new(NODEJS_BASE_URL),
       legacy: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, LanguagePack::Base::DEFAULT_LEGACY_STACK)
     }
     @legacy   = stack == LanguagePack::Base::DEFAULT_LEGACY_STACK
-    print "stack = #{@legacy}\n"
   end
 
   def version
@@ -35,13 +33,11 @@ class LanguagePack::NodeInstaller
   end
 
   def install
-    print "installing node\n"
     if @legacy
       @fetchers[:legacy].fetch_untar("#{LEGACY_BINARY_PATH}.tgz")
     else
       node_bin = "#{MODERN_BINARY_PATH}/bin/node"
       @fetchers[:modern].fetch_untar("#{MODERN_BINARY_PATH}.tar.gz", "#{MODERN_BINARY_PATH}/bin/node")
-      print "moving #{node_bin}\n"
       FileUtils.mv(node_bin, ".")
       FileUtils.rm_rf(MODERN_BINARY_PATH)
     end

--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -37,7 +37,7 @@ class LanguagePack::NodeInstaller
       @fetchers[:legacy].fetch_untar("#{LEGACY_BINARY_PATH}.tgz")
     else
       node_bin = "#{MODERN_BINARY_PATH}/bin/node"
-      @fetchers[:modern].fetch_untar("#{MODERN_BINARY_PATH}.tar.gz", "#{MODERN_BINARY_PATH}/bin/node")
+      @fetchers[:modern].fetch_xz("#{MODERN_BINARY_PATH}.tar.xz", "#{MODERN_BINARY_PATH}/bin/node")
       FileUtils.mv(node_bin, ".")
       FileUtils.rm_rf(MODERN_BINARY_PATH)
     end

--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -9,13 +9,13 @@ class LanguagePack::NodeInstaller
   NODEJS_BASE_URL     = "#{NODEJS_BASE}/v#{MODERN_NODE_VERSION}/"
 
   def initialize(stack)
-    print "Initialized node installer"
+    print "Initialized node installer\n"
     @fetchers = {
       modern: LanguagePack::Fetcher.new(NODEJS_BASE_URL),
       legacy: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, LanguagePack::Base::DEFAULT_LEGACY_STACK)
     }
     @legacy   = stack == LanguagePack::Base::DEFAULT_LEGACY_STACK
-    print "stack = #{@legacy}"
+    print "stack = #{@legacy}\n"
   end
 
   def version
@@ -35,13 +35,13 @@ class LanguagePack::NodeInstaller
   end
 
   def install
-    print "installing node"
+    print "installing node\n"
     if @legacy
       @fetchers[:legacy].fetch_untar("#{LEGACY_BINARY_PATH}.tgz")
     else
       node_bin = "#{MODERN_BINARY_PATH}/bin/node"
       @fetchers[:modern].fetch_untar("#{MODERN_BINARY_PATH}.tar.gz", "#{MODERN_BINARY_PATH}/bin/node")
-      print "moving #{node_bin}"
+      print "moving #{node_bin}\n"
       FileUtils.mv(node_bin, ".")
       FileUtils.rm_rf(MODERN_BINARY_PATH)
     end

--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -1,5 +1,5 @@
 class LanguagePack::NodeInstaller
-  MODERN_NODE_VERSION = "0.10.30"
+  MODERN_NODE_VERSION = "18.19.0"
   MODERN_BINARY_PATH  = "node-v#{MODERN_NODE_VERSION}-linux-x64"
 
   LEGACY_NODE_VERSION = "0.4.7"

--- a/lib/language_pack/helpers/node_installer.rb
+++ b/lib/language_pack/helpers/node_installer.rb
@@ -9,11 +9,13 @@ class LanguagePack::NodeInstaller
   NODEJS_BASE_URL     = "#{NODEJS_BASE}/v#{MODERN_NODE_VERSION}/"
 
   def initialize(stack)
+    print "Initialized node installer"
     @fetchers = {
       modern: LanguagePack::Fetcher.new(NODEJS_BASE_URL),
       legacy: LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL, LanguagePack::Base::DEFAULT_LEGACY_STACK)
     }
     @legacy   = stack == LanguagePack::Base::DEFAULT_LEGACY_STACK
+    print "stack = #{@legacy}"
   end
 
   def version
@@ -33,11 +35,13 @@ class LanguagePack::NodeInstaller
   end
 
   def install
+    print "installing node"
     if @legacy
       @fetchers[:legacy].fetch_untar("#{LEGACY_BINARY_PATH}.tgz")
     else
       node_bin = "#{MODERN_BINARY_PATH}/bin/node"
       @fetchers[:modern].fetch_untar("#{MODERN_BINARY_PATH}.tar.gz", "#{MODERN_BINARY_PATH}/bin/node")
+      print "moving #{node_bin}"
       FileUtils.mv(node_bin, ".")
       FileUtils.rm_rf(MODERN_BINARY_PATH)
     end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -544,7 +544,7 @@ WARNING
     instrument 'ruby.build_bundler' do
       log("bundle") do
         bundle_without = env("BUNDLE_WITHOUT") || "development:test"
-        bundle_bin     = "bundle"
+        bundle_bin     = "bundle config --global ssl_verify_mode 0 && bundle"
         bundle_command = "#{bundle_bin} install --without #{bundle_without} --path vendor/bundle --binstubs #{bundler_binstubs_path}"
         bundle_command << " -j4"
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -798,8 +798,21 @@ params = CGI.parse(uri.query || "")
     else
       @node_preinstall_bin_path = false
     end
+    # on alma container, `which` binary is present and it will find `node`
+    # from `/usr/local/bin/node` as a result of which node is considered 
+    # `preinstalled` and the real node is not installed in the right place.
+    # lets ignore this path in this branch.
+    # HACK ALERT
+    if force_node_install?
+      print "forcing node install"
+      @node_preinstall_bin_path = false
+    end
   end
   alias :node_js_installed? :node_preinstall_bin_path
+
+  def force_node_install?
+    ENV["FORCE_NODE_INSTALL"].to_s.downcase == "true" || false
+  end
 
   def node_not_preinstalled?
     print "node_js_installed is #{node_js_installed?}\n"

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -802,7 +802,7 @@ params = CGI.parse(uri.query || "")
   alias :node_js_installed? :node_preinstall_bin_path
 
   def node_not_preinstalled?
-    print "node_js_installed is #{node_js_installed}\n"
+    print "node_js_installed is #{node_js_installed?}\n"
     !node_js_installed?
   end
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -811,7 +811,13 @@ params = CGI.parse(uri.query || "")
   alias :node_js_installed? :node_preinstall_bin_path
 
   def force_node_install?
-    ENV["FORCE_NODE_INSTALL"].to_s.downcase == "true" || false
+    a? = ENV["FORCE_NODE_INSTALL"]
+    print "FORCE_NODE_INSTALL is #{a?}\n"
+    if a?
+      a?.to_s.downcase == "true"
+    else
+      false
+    end
   end
 
   def node_not_preinstalled?

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -811,10 +811,10 @@ params = CGI.parse(uri.query || "")
   alias :node_js_installed? :node_preinstall_bin_path
 
   def force_node_install?
-    a? = ENV["FORCE_NODE_INSTALL"]
-    print "FORCE_NODE_INSTALL is #{a?}\n"
-    if a?
-      a?.to_s.downcase == "true"
+    a = ENV["FORCE_NODE_INSTALL"]
+    print "FORCE_NODE_INSTALL is #{a}\n"
+    if a
+      a.to_s.downcase == "true"
     else
       false
     end

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -785,12 +785,10 @@ params = CGI.parse(uri.query || "")
   # checks if node.js is installed via the official heroku-buildpack-nodejs using multibuildpack
   # @return String if it's detected and false if it isn't
   def node_preinstall_bin_path
-    print "node_preinstall_bin_path at #{@node_preinstall_bin_path} \n"
     return @node_preinstall_bin_path if defined?(@node_preinstall_bin_path)
 
     legacy_path = "#{Dir.pwd}/#{NODE_BP_PATH}"
     path        = run("which node")
-    print "node path #{path} \n"
     if path && $?.success?
       @node_preinstall_bin_path = path
     elsif run("#{legacy_path}/node -v") && $?.success?
@@ -804,24 +802,17 @@ params = CGI.parse(uri.query || "")
     # lets ignore this path in this branch.
     # HACK ALERT
     if force_node_install?
-      print "forcing node install"
+      print "forcing node install\n"
       @node_preinstall_bin_path = false
     end
   end
   alias :node_js_installed? :node_preinstall_bin_path
 
   def force_node_install?
-    a = ENV["FORCE_NODE_INSTALL"]
-    print "FORCE_NODE_INSTALL is #{a}\n"
-    if a
-      a.to_s.downcase == "true"
-    else
-      false
-    end
+    ENV["FORCE_NODE_INSTALL"].to_s.downcase == "true" || false
   end
 
   def node_not_preinstalled?
-    print "node_js_installed is #{node_js_installed?}\n"
     !node_js_installed?
   end
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -802,6 +802,7 @@ params = CGI.parse(uri.query || "")
   alias :node_js_installed? :node_preinstall_bin_path
 
   def node_not_preinstalled?
+    print "node_js_installed is #{node_js_installed}\n"
     !node_js_installed?
   end
 

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -460,6 +460,7 @@ ERROR
   # default set of binaries to install
   # @return [Array] resulting list
   def binaries
+    print "add_node_js_binary #{add_node_js_binary}\n"
     add_node_js_binary
   end
 
@@ -784,10 +785,12 @@ params = CGI.parse(uri.query || "")
   # checks if node.js is installed via the official heroku-buildpack-nodejs using multibuildpack
   # @return String if it's detected and false if it isn't
   def node_preinstall_bin_path
+    print "node_preinstall_bin_path at #{@node_preinstall_bin_path} \n"
     return @node_preinstall_bin_path if defined?(@node_preinstall_bin_path)
 
     legacy_path = "#{Dir.pwd}/#{NODE_BP_PATH}"
     path        = run("which node")
+    print "node path #{path} \n"
     if path && $?.success?
       @node_preinstall_bin_path = path
     elsif run("#{legacy_path}/node -v") && $?.success?

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -12,7 +12,7 @@ require "language_pack/version"
 # base Ruby Language Pack. This is for any base ruby app.
 class LanguagePack::Ruby < LanguagePack::Base
   NAME                 = "ruby"
-  LIBYAML_VERSION      = "0.1.7"
+  LIBYAML_VERSION      = "0.2.5"
   LIBYAML_PATH         = "libyaml-#{LIBYAML_VERSION}"
   BUNDLER_VERSION      = "1.11.2"
   BUNDLER_GEM_PATH     = "bundler-#{BUNDLER_VERSION}"


### PR DESCRIPTION
Move away from buildcurl and use a local location on disk for ruby, bundler, libyaml.
updated yaml version
force node install since on alma container `which` is present and heroku runs `which node` and finds `/usr/local/bin/node` and thinks that node no longer needs to be installed. on centos7 `which` is not present and that fails searching for node binary and so node is installed.